### PR TITLE
TVPF-19186 - Latest shaka player version v4.3.2 not playing HLS on ch…

### DIFF
--- a/lib/polyfill/media_capabilities.js
+++ b/lib/polyfill/media_capabilities.js
@@ -110,7 +110,7 @@ shaka.polyfill.MediaCapabilities = class {
       // See: https://github.com/shaka-project/shaka-player/issues/4726
       if (videoConfig) {
         let isSupported;
-        if (shaka.util.Platform.isChromecast()) {
+        if (!shaka.util.Platform.isChromecast()) {
           isSupported =
               shaka.polyfill.MediaCapabilities.canCastDisplayType_(videoConfig);
         } else {


### PR DESCRIPTION
TVPF-19186 - Shaka player version v4.3.2 not playing HLS on crome/87.0.4280.141

Issue : Read Crkey in useragent and MimeType support is not correct

Fix : call isSupportedType() on TV for pass the MiMeType.